### PR TITLE
Replace the use of deprecated members with the replacement.

### DIFF
--- a/lib/src/riff_switch.dart
+++ b/lib/src/riff_switch.dart
@@ -249,7 +249,7 @@ class RiffSwitch extends StatelessWidget {
   /// });
   /// ```
 
-  final MaterialStateProperty<Color?>? trackColor;
+  final WidgetStateProperty<Color?>? trackColor;
 
   /// - The type of the RiffSwitch.
   ///


### PR DESCRIPTION
Code migration detail:

`MaterialState` to `WidgetState`
`MaterialStateProperty` to `WidgetStateProperty`
`surfaceVariant` to `surfaceContainerHighest`