### PR TITLE
Add comprehensive widget tests for RiffSwitch

### DIFF
--- a/test/riff_switch_test.dart
+++ b/test/riff_switch_test.dart
@@ -1,18 +1,149 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riff_switch/riff_switch.dart';
 
 void main() {
   testWidgets('Widget test for the riff_switch custom widget', (widgetTester) async {
-    await widgetTester.pumpWidget(RiffSwitch(
-      value: false,
-      onChanged: (value) {},
-      type: RiffSwitchType.simple,
-    ));
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RiffSwitch(
+            value: false,
+            onChanged: (value) {},
+            type: RiffSwitchType.simple,
+          ),
+        ),
+      ),
+    );
 
     final Finder finder = find.byWidgetPredicate(
-      (widget) => widget is RiffSwitch && widget.value == false,
+          (widget) => widget is RiffSwitch && widget.value == false,
     );
 
     expect(finder, findsOneWidget);
+  });
+
+  testWidgets('Tapping the switch changes its value', (widgetTester) async {
+    bool switchValue = false; // Toggle to test for both cases
+
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return RiffSwitch(
+                value: switchValue,
+                onChanged: (value) {
+                  setState(() {
+                    switchValue = value;
+                  });
+                },
+                type: RiffSwitchType.simple,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final Finder switchFinder = find.byType(RiffSwitch);
+
+    // Get the size and position of the switch
+    final Rect switchRect = widgetTester.getRect(switchFinder);
+
+    // Calculate the tap position on the right side for true
+    final Offset tapPosition = Offset(switchRect.right - 1, switchRect.center.dy);
+
+    // Tap the calculated position
+    await widgetTester.tapAt(tapPosition);
+    await widgetTester.pumpAndSettle();
+
+    // Verify the switch's value has changed
+    expect(switchValue, true); // Toggle to test for both cases
+  });
+
+
+  testWidgets('RiffSwitch has correct initial state', (widgetTester) async {
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RiffSwitch(
+            value: true,
+            onChanged: (value) {},
+            type: RiffSwitchType.simple,
+          ),
+        ),
+      ),
+    );
+
+    final Finder finder = find.byWidgetPredicate(
+          (widget) => widget is RiffSwitch && widget.value == true,
+    );
+
+    expect(finder, findsOneWidget);
+  });
+
+  testWidgets('RiffSwitch renders correctly', (widgetTester) async {
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RiffSwitch(
+            value: false,
+            onChanged: (value) {},
+            type: RiffSwitchType.simple,
+          ),
+        ),
+      ),
+    );
+
+    // Verify the widget renders with the correct initial value
+    expect(find.byType(RiffSwitch), findsOneWidget);
+    expect(find.byWidgetPredicate((widget) => widget is RiffSwitch && widget.value == false), findsOneWidget);
+  });
+
+  testWidgets('RiffSwitch onChanged callback is triggered', (widgetTester) async {
+    bool wasCalled = false;
+
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RiffSwitch(
+            value: false,
+            onChanged: (value) {
+              wasCalled = true;
+            },
+            type: RiffSwitchType.simple,
+          ),
+        ),
+      ),
+    );
+
+    final Finder switchFinder = find.byType(RiffSwitch);
+
+    // Tap the switch
+    await widgetTester.tap(switchFinder);
+    await widgetTester.pumpAndSettle();
+
+    // Verify the callback was triggered
+    expect(wasCalled, true);
+  });
+
+  testWidgets('RiffSwitch renders correctly for different types', (widgetTester) async {
+    for (var type in RiffSwitchType.values) {
+      await widgetTester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RiffSwitch(
+              value: false,
+              onChanged: (value) {},
+              type: type,
+            ),
+          ),
+        ),
+      );
+
+      // Verify the widget renders correctly for each type
+      expect(find.byType(RiffSwitch), findsOneWidget);
+    }
   });
 }


### PR DESCRIPTION
This pull request adds and updates the test cases for the `RiffSwitch` widget to ensure its functionality and visual correctness. The following tests have been included:

1. **Initial State Test**:
   - Verifies that the `RiffSwitch` widget initializes with the correct value (`true` or `false`).

2. **Toggle State Test**:
   - Simulates a tap on the right side of the switch to change its value from `false` to `true`.
   - Confirms that the switch's state updates correctly upon interaction.

3. **Rendering Test**:
   - Ensures the `RiffSwitch` widget renders correctly with the specified initial value.
   - Confirms the widget is visible and correctly reflects its state.

4. **Callback Trigger Test**:
   - Validates that the `onChanged` callback is triggered when the switch is tapped.
   - Ensures the callback behaves as expected.

5. **Rendering for Different Types**:
   - Tests the rendering of the `RiffSwitch` widget for each type defined in `RiffSwitchType`.
   - Confirms that the widget renders correctly for various types.

These changes enhance the test coverage for the `RiffSwitch` widget and ensure its reliable behavior in different scenarios.

### Changes:
- Added new test cases to `riff_switch_test.dart` file.
- Updated tests to accurately simulate user interactions and verify state changes.
